### PR TITLE
WIP Stub for lenses

### DIFF
--- a/lib/immutable/lens.pm
+++ b/lib/immutable/lens.pm
@@ -16,6 +16,11 @@ sub set {
   $self->{'set'}($obj, $value);
 }
 
+sub modify {
+  my ($self, $obj, $fn) = @_;
+  $self->set($obj, $fn->($self->view($obj)));
+}
+
 sub compose {
   my ($self, $other) = @_;
   die "Can only compose lenses together" unless ref($self) eq ref($other);

--- a/lib/immutable/lens.pm
+++ b/lib/immutable/lens.pm
@@ -1,0 +1,34 @@
+use strict; use warnings;
+package immutable::lens;
+
+sub make {
+  my ($class, $view, $set) = @_;
+  bless {view => $view, set => $set}, $class;
+}
+
+sub view {
+  my ($self, $obj) = @_;
+  $self->{'view'}($obj);
+}
+
+sub set {
+  my ($self, $obj, $value) = @_;
+  $self->{'set'}($obj, $value);
+}
+
+sub compose {
+  my ($self, $other) = @_;
+  die "Can only compose lenses together" unless ref($self) eq ref($other);
+  my $view = sub {
+    $other->view($self->view($_[0]))
+  };
+  my $set = sub { 
+    my ($obj, $value) = @_;
+    my $current_inner = $self->view($obj);
+    my $updated_inner = $other->set($current_inner, $value);
+    $self->set($obj, $updated_inner);
+  };
+  bless {view => $view, set => $set}, ref($self);
+}
+
+1;

--- a/lib/immutable/lens.pm
+++ b/lib/immutable/lens.pm
@@ -8,12 +8,12 @@ sub make {
 
 sub view {
   my ($self, $obj) = @_;
-  $self->{'view'}($obj);
+  $self->{view}($obj);
 }
 
 sub set {
   my ($self, $obj, $value) = @_;
-  $self->{'set'}($obj, $value);
+  $self->{set}($obj, $value);
 }
 
 sub modify {

--- a/test/03-lens.t
+++ b/test/03-lens.t
@@ -1,0 +1,82 @@
+use strict; use warnings;
+use Test::More;
+
+use immutable::0 ':all';
+use immutable::lens;
+
+sub street {
+  my ($name, $number) = @_;
+  bless {name => $name, number => $number}, 'Street'
+}
+my $street = street 'St James', 10;
+
+sub address {
+  my ($country, $street) = @_;
+  bless {country => $country, street => $street}, 'Address';
+}
+my $address = address 'GB', $street;
+
+my $address_street_lens = immutable::lens->make(
+  sub { $_[0]->{'street'} },
+  sub {
+    my ($address, $new_street) = @_;
+    address $address->{'country'}, $new_street;
+  });
+my $street_number_lens = immutable::lens->make(
+  sub { $_[0]->{'number'} },
+  sub {
+    my ($street, $new_street_number) = @_;
+    street $street->{'name'}, $new_street_number;
+  });
+
+is $street_number_lens->view($street), 10,
+  'can view a lens';
+
+{
+  my $new_street = $street_number_lens->set($street, 11);
+  is $new_street->{'name'}, $street->{'name'},
+    'other properties aren\'t updated';
+  is $new_street->{'number'}, 11,
+    'lens property is updated';
+  is $street->{'number'}, 10,
+    'original object is left unchanged';
+}
+
+{
+  my $address_street = $address_street_lens->view($address);
+  is $address_street, $street,
+    'can view an object through a lens';
+}
+
+{
+  my $new_street = $street_number_lens->set($street, 11);
+  my $new_address = $address_street_lens->set($address, $new_street);
+  is $new_address->{'street'}, $new_street,
+    'lens property updated an object';
+  is $address_street_lens->view($new_address), $new_street,
+    'lens property updated an object';
+  is $address->{'street'}, $street,
+    'original object is left unchanged';
+  is $address_street_lens->view($address), $street,
+    'original object viewed is left unchanged';
+}
+
+{
+  my $composed = $address_street_lens->compose($street_number_lens);
+  is $composed->view($address), 10,
+    'can view a composed lens';
+  my $new_address = $composed->set($address, 11);
+  is $composed->view($address), 10,
+    'composed lens left original unchanged';
+  is $composed->view($new_address), 11,
+    'lens property updated a nested object';
+  is $new_address->{'street'}{'number'}, 11,
+    'lens property updated a nested object';
+  my $new_street = $address_street_lens->view($new_address);
+  is $new_street->{'number'}, 11,
+    'viewed element was updated after composed set';
+  is $street_number_lens->view($new_street), 11,
+    'reapplying a second view gets the proper deep updated object';
+}
+
+done_testing;

--- a/test/03-lens.t
+++ b/test/03-lens.t
@@ -43,6 +43,14 @@ is $street_number_lens->view($street), 10,
 }
 
 {
+  my $new_street = $street_number_lens->modify($street, sub {$_[0] * 2});
+  is $new_street->{'number'}, 20,
+    'modify passes the current value';
+  is $street_number_lens->view($new_street), 20,
+    'modify passes the current value';
+}
+
+{
   my $address_street = $address_street_lens->view($address);
   is $address_street, $street,
     'can view an object through a lens';
@@ -77,6 +85,15 @@ is $street_number_lens->view($street), 10,
     'viewed element was updated after composed set';
   is $street_number_lens->view($new_street), 11,
     'reapplying a second view gets the proper deep updated object';
+}
+
+{
+  my $composed = $address_street_lens->compose($street_number_lens);
+  my $new_address = $composed->modify($address, sub { $_[0] * 2 });
+  is $composed->view($address), 10,
+    'composed lens left original unchanged';
+  is $composed->view($new_address), 20,
+    'lens property updated a nested object';
 }
 
 done_testing;


### PR DESCRIPTION
Here's an idea I wanted to lay out: lenses for `immutable`.
I really like this module and I really want to use it, but I think as it is, deep updates are going to be painful.
Thankfully, that problem's been solved for a few years already!

Here follows a simple implementation of lenses, with only three operations: `view`, `set`, `compose`. Nothing else, nothing more.

This isn't meant to be a "serious" implementation that wants to get merged, just to get some discussion rolling.

Note: I'm not a good Perl dev (or a Perl dev at all, honestly, I learned Raku first), so there are probably things I'm doing wrong.

Generating the lens could probably be improved, we could imagine a function like this for `get`:
```perl
sub prop {
  my $name = shift;
  sub { $_->{$name} }
}
my $address_street_lens = immutable::lens->make(prop('street'),
```
I'm unsure if there's a general cloning mechanism for generalizing `set` in OO world(s), so I'm unsure.

Anyway, here's to nothing, except what I hope is an interesting idea.